### PR TITLE
Use strings.Prefix instead of checking slice

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func readKernelConfig() error {
 				continue
 			}
 
-		} else if kv[0][0:4] == "pcd." {
+		} else if strings.HasPrefix(kv[0], "pcd.") {
 			kernel[kv[0]] = kv[1]
 		} else if kv[0] == "hostname" {
 			kernel[kv[0]] = kv[1]


### PR DESCRIPTION
This addresses an index out of range problem in a scenario where a bootloader passes a kernel command line with a key less than 4 bytes in length, such as ip=dhcp.

I confess I haven't tried to build this yet. Maybe travis will try for me?